### PR TITLE
Quick fix for last failure of integration stage

### DIFF
--- a/features/steps/inventory_steps.py
+++ b/features/steps/inventory_steps.py
@@ -134,7 +134,7 @@ def step_impl(context, key, value):
 def step_impl(context, text_string, element_name):
     found = WebDriverWait(context.driver, WAIT_SECONDS).until(
         expected_conditions.text_to_be_present_in_element_value(
-            (By.ID, element_id),
+            (By.ID, element_name),
             text_string
         )
     )


### PR DESCRIPTION
    Then I should see "top" in the "Name" field # features/steps/inventory_steps.py:133
      Traceback (most recent call last):
        File "/home/pipeline/d9fe987d-0bfa-4daf-be17-6744f1c18ff0/venv/local/lib/python2.7/site-packages/behave/model.py", line 1456, in run
          match.run(runner.context)
        File "/home/pipeline/d9fe987d-0bfa-4daf-be17-6744f1c18ff0/venv/local/lib/python2.7/site-packages/behave/model.py", line 1903, in run
          self.func(context, *args, **kwargs)
        File "features/steps/inventory_steps.py", line 137, in step_impl
          (By.ID, element_id),
      NameError: global name 'element_id' is not defined